### PR TITLE
split generate into generate + publish for PR compatibility

### DIFF
--- a/.github/workflows/agentic-marketplace.yml
+++ b/.github/workflows/agentic-marketplace.yml
@@ -11,7 +11,7 @@ on:
         default: true
         type: boolean
       dry-run:
-        description: 'Preview changes without committing'
+        description: 'Skip publish step (PR creation, auto-merge, releases)'
         default: false
         type: boolean
       create-opencode-release:
@@ -61,6 +61,20 @@ jobs:
 
   generate:
     needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Generate marketplace files
+        uses: bitcomplete/bc-github-actions/agentic-marketplace/generate@v1
+        with:
+          config-path: ${{ inputs.config-path }}
+
+  publish:
+    needs: generate
     if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     permissions:
@@ -77,6 +91,10 @@ jobs:
         uses: bitcomplete/bc-github-actions/agentic-marketplace/generate@v1
         with:
           config-path: ${{ inputs.config-path }}
+
+      - name: Publish marketplace changes
+        uses: bitcomplete/bc-github-actions/agentic-marketplace/publish@v1
+        with:
           github-token: ${{ secrets.token }}
           auto-merge: ${{ inputs.auto-merge }}
           create-opencode-release: ${{ inputs.create-opencode-release }}

--- a/agentic-marketplace/generate/action.yml
+++ b/agentic-marketplace/generate/action.yml
@@ -7,36 +7,6 @@ inputs:
     description: 'Path to generator.config.toml'
     required: false
     default: '.claude-plugin/generator.config.toml'
-  github-token:
-    description: 'GitHub token for creating PRs'
-    required: true
-  auto-merge:
-    description: 'Enable auto-merge for generated PR'
-    required: false
-    default: 'true'
-  dry-run:
-    description: 'Preview changes without committing'
-    required: false
-    default: 'false'
-  create-opencode-release:
-    description: 'Create OpenCode-compatible plugin releases'
-    required: false
-    default: 'false'
-  release-version:
-    description: 'Version for releases (default: YYYY.MM.DD)'
-    required: false
-    default: ''
-
-outputs:
-  pr-number:
-    description: 'Pull request number if created'
-    value: ${{ steps.create-pr.outputs.pull-request-number }}
-  pr-url:
-    description: 'Pull request URL if created'
-    value: ${{ steps.create-pr.outputs.pull-request-url }}
-  releases-created:
-    description: 'Number of OpenCode releases created'
-    value: ${{ steps.opencode-release.outputs.count }}
 
 runs:
   using: 'composite'
@@ -60,75 +30,6 @@ runs:
         node "$SCRIPT_PATH" generate
 
         echo "✓ Generation complete"
-
-    - name: Create Pull Request
-      id: create-pr
-      if: ${{ inputs.dry-run != 'true' }}
-      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
-      with:
-        token: ${{ inputs.github-token }}
-        base: main
-        commit-message: 'chore: update marketplace.json'
-        title: 'chore: update marketplace.json'
-        body: |
-          Auto-generated marketplace.json and plugin.json updates from plugin component changes.
-
-          This PR is automatically created when plugin components are added, modified, or removed on the main branch.
-
-          The files are regenerated based on:
-          - Plugins discovered in two-level hierarchy: `category/plugin-name/`
-          - Plugin components: agents/, commands/, skills/
-          - Hooks in `hooks/hooks.json`
-          - MCP servers in `.mcp.json`
-          - Settings in `.claude-plugin/generator.config.toml` or `.claude-plugin/generator.config.json`
-
-          **Generated files:**
-          - `.claude-plugin/marketplace.json` - marketplace manifest with unique source paths per plugin
-          - `category/plugin-name/.claude-plugin/plugin.json` - individual plugin metadata
-
-          **This PR will auto-merge after CI checks pass.**
-        branch: auto-update-marketplace
-        delete-branch: true
-        labels: |
-          automated
-          marketplace
-
-    - name: Enable auto-merge
-      if: ${{ inputs.dry-run != 'true' && inputs.auto-merge == 'true' && steps.create-pr.outputs.pull-request-number != '' }}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
-        PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-      run: |
-        if [ -n "$PR_NUMBER" ]; then
-          echo "Enabling auto-merge for PR #$PR_NUMBER"
-          gh pr merge "$PR_NUMBER" --auto --squash
-        else
-          echo "No PR created (no changes detected)"
-        fi
-
-    - name: Create OpenCode Releases
-      id: opencode-release
-      if: ${{ inputs.create-opencode-release == 'true' && inputs.dry-run != 'true' }}
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-        RELEASE_VERSION: ${{ inputs.release-version }}
-      run: |
-        set -e
-
-        # Use bundled script from this action
-        SCRIPT_PATH="${GITHUB_ACTION_PATH}/../../scripts/dist/opencode-release.cjs"
-
-        if [ ! -f "$SCRIPT_PATH" ]; then
-          echo "ERROR: Bundled script not found at $SCRIPT_PATH" >&2
-          exit 1
-        fi
-
-        echo "Creating OpenCode releases..."
-        node "$SCRIPT_PATH" opencode-release
-
-        echo "✓ Release creation complete"
 
 branding:
   icon: 'file-text'

--- a/agentic-marketplace/publish/action.yml
+++ b/agentic-marketplace/publish/action.yml
@@ -1,0 +1,104 @@
+name: 'Publish Marketplace Changes'
+description: 'Creates a PR with marketplace changes, enables auto-merge, and creates OpenCode releases'
+author: 'Bitcomplete'
+
+inputs:
+  github-token:
+    description: 'GitHub token for creating PRs'
+    required: true
+  auto-merge:
+    description: 'Enable auto-merge for generated PR'
+    required: false
+    default: 'true'
+  create-opencode-release:
+    description: 'Create OpenCode-compatible plugin releases'
+    required: false
+    default: 'false'
+  release-version:
+    description: 'Version for releases (default: YYYY.MM.DD)'
+    required: false
+    default: ''
+
+outputs:
+  pr-number:
+    description: 'Pull request number if created'
+    value: ${{ steps.create-pr.outputs.pull-request-number }}
+  pr-url:
+    description: 'Pull request URL if created'
+    value: ${{ steps.create-pr.outputs.pull-request-url }}
+  releases-created:
+    description: 'Number of OpenCode releases created'
+    value: ${{ steps.opencode-release.outputs.count }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Create Pull Request
+      id: create-pr
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+      with:
+        token: ${{ inputs.github-token }}
+        base: main
+        commit-message: 'chore: update marketplace.json'
+        title: 'chore: update marketplace.json'
+        body: |
+          Auto-generated marketplace.json and plugin.json updates from plugin component changes.
+
+          This PR is automatically created when plugin components are added, modified, or removed on the main branch.
+
+          The files are regenerated based on:
+          - Plugins discovered in two-level hierarchy: `category/plugin-name/`
+          - Plugin components: agents/, commands/, skills/
+          - Hooks in `hooks/hooks.json`
+          - MCP servers in `.mcp.json`
+          - Settings in `.claude-plugin/generator.config.toml` or `.claude-plugin/generator.config.json`
+
+          **Generated files:**
+          - `.claude-plugin/marketplace.json` - marketplace manifest with unique source paths per plugin
+          - `category/plugin-name/.claude-plugin/plugin.json` - individual plugin metadata
+
+          **This PR will auto-merge after CI checks pass.**
+        branch: auto-update-marketplace
+        delete-branch: true
+        labels: |
+          automated
+          marketplace
+
+    - name: Enable auto-merge
+      if: ${{ inputs.auto-merge == 'true' && steps.create-pr.outputs.pull-request-number != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+      run: |
+        echo "Enabling auto-merge for PR #$PR_NUMBER"
+        if ! gh pr merge "$PR_NUMBER" --auto --squash; then
+          echo "::warning::Auto-merge could not be enabled (allow_auto_merge may not be enabled on this repo)"
+        fi
+
+    - name: Create OpenCode Releases
+      id: opencode-release
+      if: ${{ inputs.create-opencode-release == 'true' }}
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        RELEASE_VERSION: ${{ inputs.release-version }}
+      run: |
+        set -e
+
+        # Use bundled script from this action
+        SCRIPT_PATH="${GITHUB_ACTION_PATH}/../../scripts/dist/opencode-release.cjs"
+
+        if [ ! -f "$SCRIPT_PATH" ]; then
+          echo "ERROR: Bundled script not found at $SCRIPT_PATH" >&2
+          exit 1
+        fi
+
+        echo "Creating OpenCode releases..."
+        node "$SCRIPT_PATH" opencode-release
+
+        echo "✓ Release creation complete"
+
+branding:
+  icon: 'upload-cloud'
+  color: 'purple'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-github-actions",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Reusable GitHub Actions workflows for Claude Code plugin marketplaces",
   "private": false,
   "scripts": {


### PR DESCRIPTION
## Summary
- Split the `generate` composite action into `generate` (pure file generation) and `publish` (PR creation, auto-merge, releases)
- Split the workflow's `generate` job so it always runs (can be a required status check on PRs), with a new `publish` job gated by `dry-run`
- Auto-merge failure now warns instead of failing the workflow (for repos without `allow_auto_merge` enabled)
- Bumps version to 1.0.2

## Test plan
- [ ] CI passes (test.yml)
- [ ] On PR: discover, validate, generate all run and report status (publish skipped)
- [ ] On push to main: all 4 jobs run, PR created with marketplace changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)