### PR TITLE
fix: gate publish job on push events only

### DIFF
--- a/.github/workflows/agentic-marketplace.yml
+++ b/.github/workflows/agentic-marketplace.yml
@@ -75,7 +75,7 @@ jobs:
 
   publish:
     needs: generate
-    if: ${{ !inputs.dry-run }}
+    if: ${{ !inputs.dry-run && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-github-actions",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Reusable GitHub Actions workflows for Claude Code plugin marketplaces",
   "private": false,
   "scripts": {


### PR DESCRIPTION
## Summary
- Add `github.event_name == 'push'` to the publish job condition so it never runs on PR CI events
- `dry-run` alone wasn't sufficient — callers that didn't pass `dry-run: true` on PRs would trigger PR creation (e.g. PR #40 from PR #38's CI run)
- Bumps version to 1.0.3

## Test plan
- [ ] CI passes
- [ ] On PR: discover, validate, generate run; publish is skipped
- [ ] On push to main: all 4 jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)