### PR TITLE
fix: use PAT for publish to trigger workflows on created PRs

### DIFF
--- a/.github/workflows/agentic-marketplace.yml
+++ b/.github/workflows/agentic-marketplace.yml
@@ -24,7 +24,10 @@ on:
         type: string
     secrets:
       token:
-        description: 'GitHub token for PR creation'
+        description: 'GitHub token for read-only operations'
+        required: true
+      pat:
+        description: 'Personal access token for PR creation (PRs created with GITHUB_TOKEN do not trigger workflows)'
         required: true
 
 jobs:
@@ -95,7 +98,7 @@ jobs:
       - name: Publish marketplace changes
         uses: bitcomplete/bc-github-actions/agentic-marketplace/publish@v1
         with:
-          github-token: ${{ secrets.token }}
+          github-token: ${{ secrets.pat }}
           auto-merge: ${{ inputs.auto-merge }}
           create-opencode-release: ${{ inputs.create-opencode-release }}
           release-version: ${{ inputs.release-version }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-github-actions",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Reusable GitHub Actions workflows for Claude Code plugin marketplaces",
   "private": false,
   "scripts": {


### PR DESCRIPTION
## Summary
- Add separate `pat` secret for the publish job — PRs created with `GITHUB_TOKEN` don't trigger workflows (GitHub's infinite loop prevention), so required checks never run
- `token` remains for read-only operations (discover, validate, generate)
- `pat` is used for PR creation and auto-merge in the publish job
- Bumps version to 1.0.4

Callers update to:
```yaml
secrets:
  token: ${{ secrets.GITHUB_TOKEN }}
  pat: ${{ secrets.PAT }}
```

## Test plan
- [ ] CI passes
- [ ] On push to main: publish job creates PR using PAT, workflows trigger on the created PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)