### PR TITLE
fix: handle nested hooks.json, skip frontmatterless markdown, fix error display

### DIFF
--- a/agentic-marketplace/discover/action.yml
+++ b/agentic-marketplace/discover/action.yml
@@ -36,9 +36,7 @@ runs:
         fi
 
         echo "Discovering components..."
-        OUTPUT=$(node "$SCRIPT_PATH" discover-all 2>&1)
-
-        if [ $? -ne 0 ]; then
+        if ! OUTPUT=$(node "$SCRIPT_PATH" discover-all 2>&1); then
           echo "ERROR: Discovery failed" >&2
           echo "$OUTPUT" >&2
           exit 1


### PR DESCRIPTION
## Summary

- Fix `mergeHooks()` crash on nested hooks.json format (`{ description, hooks: { ... } }`)
- Require frontmatter for heuristic markdown classification — silently skip reference docs and planning notes
- Fix `action.yml` error display dead code (`set -e` + `$?` check → `if !` pattern)
- Add 11 tests covering mergeHooks formats and classifyComponent edge cases

## Context

Two PRs in bc-llm-skills have failing CI:
- PR #43 (design engineering plugin): crashes discover job — hooks.json has nested format
- PR #42 (BitHub MCP integration): fails validate — `PLAN-mcp-auth-post.md` has no frontmatter

## Test plan

- [x] `npm test` passes (23/23)
- [x] `npm run build` regenerates dist
- [x] Verified against PR #43 branch: no crash, hooks discovered, `references/*.md` skipped
- [x] Verified against PR #42 branch: `PLAN-mcp-auth-post.md` skipped, zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)