### PR TITLE
fix: show diff instead of full JSON in generate summary

### DIFF
--- a/agentic-marketplace/generate/action.yml
+++ b/agentic-marketplace/generate/action.yml
@@ -29,11 +29,12 @@ runs:
         MARKETPLACE_FILE=".claude-plugin/marketplace.json"
 
         # Save existing marketplace.json for comparison
+        BEFORE_FILE=$(mktemp)
         if [ -f "$MARKETPLACE_FILE" ]; then
-          BEFORE=$(cat "$MARKETPLACE_FILE")
+          cp "$MARKETPLACE_FILE" "$BEFORE_FILE"
           HAD_FILE=true
         else
-          BEFORE=""
+          : > "$BEFORE_FILE"
           HAD_FILE=false
         fi
 
@@ -42,46 +43,27 @@ runs:
 
         # Write job summary
         if [ -n "$GITHUB_STEP_SUMMARY" ]; then
-          if [ -f "$MARKETPLACE_FILE" ]; then
-            AFTER=$(cat "$MARKETPLACE_FILE")
-          else
-            AFTER=""
-          fi
-
           {
             echo "### Generate"
             echo ""
 
-            if [ "$HAD_FILE" = "false" ] && [ -n "$AFTER" ]; then
+            if [ "$HAD_FILE" = "false" ] && [ -f "$MARKETPLACE_FILE" ]; then
               echo "📄 **New file** — \`$MARKETPLACE_FILE\`"
               echo ""
-              echo "<details><summary>marketplace.json</summary>"
-              echo ""
-              echo '```json'
-              echo "$AFTER"
+              echo '```diff'
+              sed 's/^/+ /' "$MARKETPLACE_FILE"
               echo '```'
-              echo ""
-              echo "</details>"
-            elif [ "$BEFORE" = "$AFTER" ]; then
+            elif diff -q "$BEFORE_FILE" "$MARKETPLACE_FILE" > /dev/null 2>&1; then
               echo "No changes to \`$MARKETPLACE_FILE\`"
             else
-              PLUGIN_LIST=$(node -e "
-                const m = JSON.parse(process.argv[1]);
-                m.plugins.forEach(p => console.log('- **' + p.name + '** (' + p.category + '): ' + p.description));
-              " "$AFTER")
               echo "📦 **Updated** \`$MARKETPLACE_FILE\`"
               echo ""
-              echo "$PLUGIN_LIST"
-              echo ""
-              echo "<details><summary>Full marketplace.json</summary>"
-              echo ""
-              echo '```json'
-              echo "$AFTER"
+              echo '```diff'
+              diff -u "$BEFORE_FILE" "$MARKETPLACE_FILE" | tail -n +3
               echo '```'
-              echo ""
-              echo "</details>"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+          rm -f "$BEFORE_FILE"
         fi
 
         echo "✓ Generation complete"


### PR DESCRIPTION
## Summary

- Replace full marketplace.json dump with unified diff in the generate job summary
- New files: all lines prefixed with `+`
- Changed files: standard `diff -u` output
- Unchanged: one-line "No changes" message

Follow-up to #11.

## Test plan

- [ ] CI passes
- [ ] Re-trigger on bc-llm-skills PRs to verify diff renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)