### PR TITLE
fix: neutralize diff exit code in generate summary

### DIFF
--- a/agentic-marketplace/generate/action.yml
+++ b/agentic-marketplace/generate/action.yml
@@ -59,7 +59,8 @@ runs:
               echo "📦 **Updated** \`$MARKETPLACE_FILE\`"
               echo ""
               echo '```diff'
-              diff -u "$BEFORE_FILE" "$MARKETPLACE_FILE" | tail -n +3
+              # diff exits 1 when files differ; neutralize before the pipe
+              { diff -u "$BEFORE_FILE" "$MARKETPLACE_FILE" || true; } | tail -n +3
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`diff -u` returns exit code 1 when files differ, which kills the script under `set -e -o pipefail`. Wrap in `{ ... || true; }` before piping to `tail`.

Follow-up to #12.